### PR TITLE
Add batch funding rate API and update consumers

### DIFF
--- a/src/app/api/funding-rates/batch/route.ts
+++ b/src/app/api/funding-rates/batch/route.ts
@@ -5,15 +5,17 @@ import { FundingRatesBatchResponse } from '@/types/kraken'
 export async function POST(request: Request) {
   try {
     const body = await request.json().catch(() => null)
-    const symbols = Array.isArray(body?.symbols) ? body.symbols : []
+    const rawSymbols = body?.symbols
 
-    if (symbols.length === 0) {
+    if (!Array.isArray(rawSymbols) || rawSymbols.length === 0) {
       return NextResponse.json({ error: 'symbols array is required' }, { status: 400 })
     }
 
-    if (!symbols.every((symbol) => typeof symbol === 'string')) {
+    if (!rawSymbols.every((symbol): symbol is string => typeof symbol === 'string')) {
       return NextResponse.json({ error: 'symbols must be strings' }, { status: 400 })
     }
+
+    const symbols = rawSymbols
 
     const { ratesBySymbol, errors } = await fetchFundingRatesBatch(symbols)
     const hasErrors = Object.keys(errors).length > 0

--- a/src/app/api/funding-rates/batch/route.ts
+++ b/src/app/api/funding-rates/batch/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server'
+import { fetchFundingRatesBatch } from '@/server/fundingRates'
+import { FundingRatesBatchResponse } from '@/types/kraken'
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json().catch(() => null)
+    const symbols = Array.isArray(body?.symbols) ? body.symbols : []
+
+    if (symbols.length === 0) {
+      return NextResponse.json({ error: 'symbols array is required' }, { status: 400 })
+    }
+
+    if (!symbols.every((symbol) => typeof symbol === 'string')) {
+      return NextResponse.json({ error: 'symbols must be strings' }, { status: 400 })
+    }
+
+    const { ratesBySymbol, errors } = await fetchFundingRatesBatch(symbols)
+    const hasErrors = Object.keys(errors).length > 0
+
+    const response: FundingRatesBatchResponse = {
+      result: hasErrors ? 'partial' : 'success',
+      serverTime: new Date().toISOString(),
+      ratesBySymbol,
+      errors: hasErrors ? errors : undefined,
+    }
+
+    return NextResponse.json(response)
+  } catch (error) {
+    console.error('Batch funding rates fetch error:', error)
+    return NextResponse.json(
+      { error: 'Failed to fetch funding rates batch' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/lib/kraken.ts
+++ b/src/lib/kraken.ts
@@ -1,4 +1,4 @@
-import { TickerResponse, FundingRateResponse } from '../types/kraken'
+import { TickerResponse, FundingRateResponse, FundingRatesBatchResponse } from '../types/kraken'
 
 export async function getTickers(): Promise<TickerResponse> {
   try {
@@ -35,6 +35,31 @@ export async function getFundingRates(symbol: string): Promise<FundingRateRespon
       throw new Error(`Failed to fetch funding rates for ${symbol}: ${error.message}`)
     }
     throw new Error(`Failed to fetch funding rates for ${symbol}: Unknown error`)
+  }
+}
+
+export async function getFundingRatesBatch(symbols: string[]): Promise<FundingRatesBatchResponse> {
+  try {
+    const response = await fetch('/api/funding-rates/batch', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ symbols }),
+    })
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`)
+    }
+
+    const data = await response.json()
+    return data
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error('Error fetching funding rates batch:', error.message)
+      throw new Error(`Failed to fetch funding rates batch: ${error.message}`)
+    }
+    throw new Error('Failed to fetch funding rates batch: Unknown error')
   }
 }
 

--- a/src/server/fundingRates.ts
+++ b/src/server/fundingRates.ts
@@ -1,0 +1,79 @@
+import { startOfHour, isSameHour } from 'date-fns'
+import { FundingRateResponse } from '@/types/kraken'
+
+const cache = new Map<string, { data: FundingRateResponse; timestamp: Date }>()
+const MAX_CACHE_ENTRIES = 500
+
+export interface FundingRatesBatchFetchResult {
+  ratesBySymbol: Record<string, FundingRateResponse['rates']>
+  errors: Record<string, string>
+}
+
+export async function fetchFundingRatesForSymbol(symbol: string): Promise<FundingRateResponse> {
+  const trimmedSymbol = symbol.trim()
+  if (!trimmedSymbol) {
+    throw new Error('Symbol is required')
+  }
+
+  const now = new Date()
+  const cached = cache.get(trimmedSymbol)
+  if (cached && isSameHour(cached.timestamp, now)) {
+    return cached.data
+  }
+
+  const response = await fetch(
+    `https://futures.kraken.com/derivatives/api/v4/historicalfundingrates?symbol=${encodeURIComponent(trimmedSymbol)}`
+  )
+
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`)
+  }
+
+  const data = (await response.json()) as FundingRateResponse
+
+  cache.set(trimmedSymbol, {
+    data,
+    timestamp: startOfHour(now),
+  })
+
+  if (cache.size > MAX_CACHE_ENTRIES) {
+    const oldestKey = cache.keys().next().value
+    if (oldestKey) {
+      cache.delete(oldestKey)
+    }
+  }
+
+  return data
+}
+
+export async function fetchFundingRatesBatch(
+  symbols: string[],
+  concurrency = 10
+): Promise<FundingRatesBatchFetchResult> {
+  const uniqueSymbols = Array.from(new Set(symbols.map((symbol) => symbol.trim()).filter(Boolean)))
+  const ratesBySymbol: Record<string, FundingRateResponse['rates']> = {}
+  const errors: Record<string, string> = {}
+
+  let index = 0
+  const workerCount = Math.min(concurrency, uniqueSymbols.length)
+
+  const workers = new Array(workerCount).fill(0).map(async () => {
+    while (index < uniqueSymbols.length) {
+      const currentIndex = index
+      index += 1
+      const symbol = uniqueSymbols[currentIndex]
+
+      try {
+        const data = await fetchFundingRatesForSymbol(symbol)
+        ratesBySymbol[symbol] = data.rates
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error'
+        errors[symbol] = message
+      }
+    }
+  })
+
+  await Promise.all(workers)
+
+  return { ratesBySymbol, errors }
+}

--- a/src/types/kraken.ts
+++ b/src/types/kraken.ts
@@ -43,4 +43,11 @@ export interface FundingRateResponse {
   result: string
   serverTime: string
   rates: FundingRate[]
-} 
+}
+
+export interface FundingRatesBatchResponse {
+  result: 'success' | 'partial' | 'error'
+  serverTime: string
+  ratesBySymbol: Record<string, FundingRate[]>
+  errors?: Record<string, string>
+}


### PR DESCRIPTION
## Summary
- extract the funding rate fetcher into a shared server helper with caching and expose a batch resolver
- add a POST /api/funding-rates/batch endpoint and wire a typed client helper for front-end usage
- refactor overview and trend funding rate pages to consume batch data while preserving single-symbol modal fetches

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cbb69ca6fc8327acb3af4078b0f997